### PR TITLE
Added support for SUSE, better fail error message

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class rpcbind::params {
            $rpcbind_service = "rpcbind"
        }
        default: {
+           fail("rpcbind supports osfamilies RedHat, Suse, and Debian. Detected osfamily is ${::osfamily}")
        }
    }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,23 @@ class rpcbind::params {
                }
            }
        }
+      'Suse': {
+           case $::operatingsystem {
+               'OpenSuSE': {
+                   $rpcbind_package = "rpcbind"
+                   $rpcbind_service = "rpcbind"
+               }
+               default: {	# SLE[SD]
+                   if ($::lsbmajdistrelease < 11) {
+                       $rpcbind_package = "portmap"
+                       $rpcbind_service = "portmap"
+                   } else {
+                       $rpcbind_package = "rpcbind"
+                       $rpcbind_service = "rpcbind"
+                   }
+               }
+           }
+       }
        'Debian': {
            $rpcbind_package = "rpcbind"
            $rpcbind_service = "rpcbind"


### PR DESCRIPTION
Hi,

I added support for openSUSE, SLES, and SLED to your puppet-rpcbind package.
While I was at it, I also improved the error message on unsupported osfamilies.
I would appreciate if you could merge these changes in your Puppet Forge module.

Cheers,
Joachim
